### PR TITLE
Remove subscription reminder when issue is reported

### DIFF
--- a/src/components/feedback-dialog.tsx
+++ b/src/components/feedback-dialog.tsx
@@ -19,12 +19,14 @@ interface FeedbackDialogProps {
   subscription: Subscription;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  onDelete: (id: string) => void;
 }
 
 export function FeedbackDialog({
   subscription,
   open,
   onOpenChange,
+  onDelete,
 }: FeedbackDialogProps) {
   const [reason, setReason] = useState<FeedbackReason | "">("");
   const [description, setDescription] = useState("");
@@ -57,6 +59,8 @@ export function FeedbackDialog({
           setDescription("");
           setSubmitStatus("idle");
           onOpenChange(false);
+          // Delete the subscription after successful feedback submission
+          onDelete(subscription.id);
         }, 1500);
       } else {
         setSubmitStatus("error");
@@ -131,7 +135,7 @@ export function FeedbackDialog({
 
           {submitStatus === "success" && (
             <p className="text-sm text-green-600">
-              Thank you! Your feedback has been submitted.
+              Thank you! Your feedback has been submitted and the reminder will be removed.
             </p>
           )}
           {submitStatus === "error" && (

--- a/src/components/subscription-card.tsx
+++ b/src/components/subscription-card.tsx
@@ -114,6 +114,7 @@ export function SubscriptionCard({
       subscription={subscription}
       open={feedbackOpen}
       onOpenChange={setFeedbackOpen}
+      onDelete={onDelete}
     />
     </>
   );


### PR DESCRIPTION
When users report an issue with a subscription classification, the reminder is now automatically removed after successful feedback submission. This provides a better user experience by eliminating incorrect reminders in one action instead of requiring separate report and delete steps.

Changes:
- Modified FeedbackDialog to accept onDelete callback prop
- Call onDelete after successful feedback submission (1.5s delay)
- Updated success message to inform users the reminder will be removed
- Passed onDelete from SubscriptionCard to FeedbackDialog