### PR TITLE
Fix mobile login race condition causing server exceptions

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,6 +1,6 @@
 import { auth } from "@/lib/auth";
 import { redirect } from "next/navigation";
-import { db, settings, users } from "@/lib/db";
+import { db, settings, users, account } from "@/lib/db";
 import { eq } from "drizzle-orm";
 import { Header } from "@/components/header";
 import { SettingsForm } from "@/components/settings-form";
@@ -8,16 +8,51 @@ import { SettingsForm } from "@/components/settings-form";
 export default async function SettingsPage() {
   const session = await auth();
 
-  if (!session?.user) {
+  if (!session?.user?.email) {
     redirect("/signin");
   }
 
-  const user = await db.query.users.findFirst({
-    where: eq(users.email, session.user.email!),
+  let user = await db.query.users.findFirst({
+    where: eq(users.email, session.user.email),
   });
 
+  // Handle race condition: user might not exist in app's users table yet
+  // This can happen on mobile when the signIn event hasn't completed
   if (!user) {
-    redirect("/signin");
+    console.log("Settings: user not found in users table, attempting to create from session");
+
+    try {
+      // Get OAuth tokens from NextAuth's account table
+      const authAccount = await db.query.account.findFirst({
+        where: eq(account.userId, session.user.id),
+      });
+
+      // Create the user in the app's users table
+      const [newUser] = await db.insert(users).values({
+        email: session.user.email,
+        name: session.user.name,
+        image: session.user.image,
+        googleAccessToken: authAccount?.access_token ?? null,
+        googleRefreshToken: authAccount?.refresh_token ?? null,
+        googleTokenExpiry: authAccount?.expires_at
+          ? new Date(authAccount.expires_at * 1000)
+          : null,
+      }).returning();
+
+      user = newUser;
+      console.log("Settings: user created successfully");
+    } catch (error) {
+      // If insert fails (e.g., duplicate key), try to fetch again
+      console.log("Settings: insert failed, retrying fetch", error);
+      user = await db.query.users.findFirst({
+        where: eq(users.email, session.user.email),
+      });
+
+      if (!user) {
+        console.error("Settings: still no user after retry, redirecting to signin");
+        redirect("/signin");
+      }
+    }
   }
 
   let userSettings = await db.query.settings.findFirst({


### PR DESCRIPTION
When users log in on mobile (slower network), there was a race condition
between the signIn event handler syncing user data to the app's users table
and the dashboard/settings pages trying to access that data. This caused
server exceptions and required 2-3 login attempts to work.

The fix handles this by creating the user record on-the-fly if a valid
session exists but no corresponding user record in the app's users table.
This provides a fallback path that gracefully handles the race condition.